### PR TITLE
[JIRA ID] - fix typo in trasient.php comment

### DIFF
--- a/php/commands/transient.php
+++ b/php/commands/transient.php
@@ -40,7 +40,7 @@ class Transient_Command extends WP_CLI_Command {
 	 * <value>
 	 * : Value to be set for the transient.
 	 *
-	 * [<expiration]
+	 * [<expiration>]
 	 * : Time until expiration, in seconds.
 	 */
 	public function set( $args ) {


### PR DESCRIPTION
### Reviewers

- [x] @aussio 
- [ ] @bdurette 

cc: @tg0ffe 

### High level summary

We're forking the wp-cli repo to fix a typo in a comment block. The typo is causing smoke test errors, so we can't deploy the wp-cli upgrade.

**This is a temporary fix**. Once 0.22.0 is released at http://github.com/wp-cli/wp-cli, we need to switch back to the main repo. The temporary fix is needed because our current version of CLI (0.17.1) breaks with WP 4.4. We *have* to upgrade CLI before 0.22.0 is released. 

### Automated tests
Type | Automated?
------------ | -------------
 Unit | y
 Functional | y
 Integration | n
 Smoke | y

### Manual smoke test instructions

none

### Extra deploy steps

### Dependencies

https://github.com/wpengine/nas2/pull/3239